### PR TITLE
Add ResourceManager for Textures, Shaders and Meshes with simple garbage collection

### DIFF
--- a/src/CommonEntities.cpp
+++ b/src/CommonEntities.cpp
@@ -5,6 +5,7 @@
 #include "Globals.h"
 #include "Material.h"
 #include "PointLight.h"
+#include "ResourceManager.h"
 #include "ShaderFactory.h"
 #include "Skybox.h"
 #include "SkyboxFactory.h"
@@ -16,7 +17,7 @@ namespace CommonEntities
 std::shared_ptr<Entity> create_skybox(std::vector<std::string> const& skybox_texture_paths, std::shared_ptr<Transform> const& parent)
 {
     auto skybox = Entity::create("Skybox");
-    auto const skybox_shader = ShaderFactory::create("./res/shaders/skybox.vert", "./res/shaders/skybox.frag");
+    auto const skybox_shader = ResourceManager::get_instance().load_shader("./res/shaders/skybox.vert", "./res/shaders/skybox.frag");
     auto const skybox_material = Material::create(skybox_shader, SKYBOX_RENDER_ORDER);
 
     auto const skybox_comp = skybox->add_component<Skybox>(SkyboxFactory::create(skybox_material, skybox_texture_paths));
@@ -28,7 +29,7 @@ std::shared_ptr<Entity> create_skybox(std::vector<std::string> const& skybox_tex
 
 std::shared_ptr<Entity> create_directional_light(glm::vec3 const& diffuse, glm::vec3 const& angles, std::shared_ptr<Transform> const& parent)
 {
-    auto light_shader = ShaderFactory::create("./res/shaders/light.vert", "./res/shaders/light.frag");
+    auto const light_shader = ResourceManager::get_instance().load_shader("./res/shaders/light.vert", "./res/shaders/light.frag");
     auto const light_material = Material::create(light_shader);
 
     auto directional_light = Entity::create("DirectionalLight");
@@ -44,7 +45,7 @@ std::shared_ptr<Entity> create_directional_light(glm::vec3 const& diffuse, glm::
 
 std::shared_ptr<Entity> create_point_light(glm::vec3 const& diffuse, std::shared_ptr<Transform> const& parent)
 {
-    auto light_shader = ShaderFactory::create("./res/shaders/light.vert", "./res/shaders/light.frag");
+    auto const light_shader = ResourceManager::get_instance().load_shader("./res/shaders/light.vert", "./res/shaders/light.frag");
     auto const light_material = Material::create(light_shader);
 
     auto point_light = Entity::create("PointLight");
@@ -59,7 +60,7 @@ std::shared_ptr<Entity> create_point_light(glm::vec3 const& diffuse, std::shared
 
 std::shared_ptr<Entity> create_spot_light(glm::vec3 const& diffuse, std::shared_ptr<Transform> const& parent)
 {
-    auto light_shader = ShaderFactory::create("./res/shaders/light.vert", "./res/shaders/light.frag");
+    auto const light_shader = ResourceManager::get_instance().load_shader("./res/shaders/light.vert", "./res/shaders/light.frag");
     auto const light_material = Material::create(light_shader);
 
     auto spot_light = Entity::create("SpotLight");

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -1,10 +1,11 @@
 #include "Cube.h"
 
 #include <memory>
+#include <sstream>
 
 #include "Globals.h"
 #include "MeshFactory.h"
-#include "TextureLoader.h"
+#include "ResourceManager.h"
 
 std::shared_ptr<Cube> Cube::create()
 {
@@ -99,14 +100,17 @@ std::shared_ptr<Mesh> Cube::create_cube() const
 
     std::vector<std::shared_ptr<Texture>> diffuse_maps = {};
     if (!diffuse_texture_path.empty())
-        diffuse_maps.emplace_back(TextureLoader::get_instance()->load_texture(diffuse_texture_path, TextureType::Diffuse));
+        diffuse_maps.emplace_back(ResourceManager::get_instance().load_texture(diffuse_texture_path, TextureType::Diffuse));
 
     std::vector<std::shared_ptr<Texture>> specular_maps = {};
     if (!specular_texture_path.empty())
-        specular_maps.emplace_back(TextureLoader::get_instance()->load_texture(specular_texture_path, TextureType::Specular));
+        specular_maps.emplace_back(ResourceManager::get_instance().load_texture(specular_texture_path, TextureType::Specular));
 
     textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
     textures.insert(textures.end(), specular_maps.begin(), specular_maps.end());
 
-    return MeshFactory::create(vertices, indices, textures, m_draw_type, material);
+    std::stringstream stream;
+    stream << m_big_cube << "CUBE";
+
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), stream.str(), vertices, indices, textures, m_draw_type, material);
 }

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -95,13 +95,13 @@ std::shared_ptr<Mesh> Cube::create_cube() const
 {
     std::vector<Vertex> const vertices = m_big_cube ? InternalMeshData::big_cube.vertices : InternalMeshData::cube.vertices;
     std::vector<u32> const indices = m_big_cube ? InternalMeshData::big_cube.indices : InternalMeshData::cube.indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
-    std::vector<Texture> diffuse_maps = {};
+    std::vector<std::shared_ptr<Texture>> diffuse_maps = {};
     if (!diffuse_texture_path.empty())
         diffuse_maps.emplace_back(TextureLoader::get_instance()->load_texture(diffuse_texture_path, TextureType::Diffuse));
 
-    std::vector<Texture> specular_maps = {};
+    std::vector<std::shared_ptr<Texture>> specular_maps = {};
     if (!specular_texture_path.empty())
         specular_maps.emplace_back(TextureLoader::get_instance()->load_texture(specular_texture_path, TextureType::Specular));
 

--- a/src/Ellipse.cpp
+++ b/src/Ellipse.cpp
@@ -6,16 +6,17 @@
 #include <glm/ext/scalar_constants.hpp>
 
 #include "MeshFactory.h"
+#include "ResourceManager.h"
 
-std::shared_ptr<Ellipse> Ellipse::create()
+std::shared_ptr<class Ellipse> Ellipse::create()
 {
     auto ellipse = std::make_shared<Ellipse>(AK::Badge<Ellipse> {});
 
     return ellipse;
 }
 
-std::shared_ptr<Ellipse> Ellipse::create(float const center_x, float const center_z, float const radius_x,
-                                         float const radius_z, i32 const segment_count, std::shared_ptr<Material> const &material)
+std::shared_ptr<class Ellipse> Ellipse::create(float const center_x, float const center_z, float const radius_x,
+                                               float const radius_z, i32 const segment_count, std::shared_ptr<Material> const &material)
 {
     auto ellipse = std::make_shared<Ellipse>(AK::Badge<Ellipse> {}, center_x, center_z, radius_x, radius_z, segment_count, material);
 
@@ -66,5 +67,5 @@ std::shared_ptr<Mesh> Ellipse::create_ellipse() const
         vertices.emplace_back(vertex);
     }
 
-    return MeshFactory::create(vertices, {}, {}, m_draw_type, material, DrawFunctionType::NotIndexed);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), "ELLIPSE", vertices, {}, {}, m_draw_type, material, DrawFunctionType::NotIndexed);
 }

--- a/src/ExampleUIBar.cpp
+++ b/src/ExampleUIBar.cpp
@@ -4,7 +4,7 @@
 #include <imgui.h>
 
 #include "Entity.h"
-#include "ShaderFactory.h"
+#include "ResourceManager.h"
 
 std::shared_ptr<ExampleUIBar> ExampleUIBar::create()
 {
@@ -15,7 +15,7 @@ void ExampleUIBar::awake()
 {
     set_can_tick(true);
 
-    auto const ui_shader = ShaderFactory::create("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
+    auto const ui_shader = ResourceManager::get_instance().load_shader("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
     auto const ui_material = Material::create(ui_shader);
 
     m_sprite_background = Entity::create("Background Sprite");

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -15,6 +15,7 @@
 #include "MeshFactory.h"
 #include "Model.h"
 #include "PointLight.h"
+#include "ResourceManager.h"
 #include "ScreenText.h"
 #include "ShaderFactory.h"
 #include "Sound.h"
@@ -30,15 +31,15 @@ Game::Game(std::shared_ptr<Window> const& window) : window(window)
 
 void Game::initialize()
 {
-    auto const standard_shader = ShaderFactory::create("./res/shaders/lit.hlsl", "./res/shaders/lit.hlsl");
-    auto const plain_shader = ShaderFactory::create("./res/shaders/simple.hlsl", "./res/shaders/simple.hlsl");
-    auto const light_source_shader = ShaderFactory::create("./res/shaders/light_source.hlsl", "./res/shaders/light_source.hlsl");
+    auto const standard_shader = ResourceManager::get_instance().load_shader("./res/shaders/lit.hlsl", "./res/shaders/lit.hlsl");
+    auto const plain_shader = ResourceManager::get_instance().load_shader("./res/shaders/simple.hlsl", "./res/shaders/simple.hlsl");
+    auto const light_source_shader = ResourceManager::get_instance().load_shader("./res/shaders/light_source.hlsl", "./res/shaders/light_source.hlsl");
 
     auto const standard_material = Material::create(standard_shader);
     auto const plain_material = Material::create(plain_shader);
     auto const light_source_material = Material::create(light_source_shader);
 
-    auto const ui_shader = ShaderFactory::create("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
+    auto const ui_shader = ResourceManager::get_instance().load_shader("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
     auto const ui_material = Material::create(ui_shader, 1);
 
     m_camera = Entity::create("Camera");

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "Model.h"
-#include "ShaderFactory.h"
+#include "ResourceManager.h"
 #include "TextureLoader.h"
 
 namespace InternalMeshData
@@ -11,7 +11,7 @@ namespace InternalMeshData
 
 void light_initialize()
 {
-    default_shader = ShaderFactory::create("./res/shaders/lit.hlsl", "./res/shaders/lit.hlsl");
+    default_shader = ResourceManager::get_instance().load_shader("./res/shaders/lit.hlsl", "./res/shaders/lit.hlsl");
     default_material = Material::create(default_shader);
 }
 
@@ -136,7 +136,7 @@ void initialize()
     }
 
     // Load white texture
-    white_texture = TextureLoader::get_instance()->load_texture("./res/textures/white.jpg", TextureType::Diffuse);
+    white_texture = ResourceManager::get_instance().load_texture("./res/textures/white.jpg", TextureType::Diffuse);
 }
 
 }

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -2,6 +2,7 @@
 
 #include "Material.h"
 
+#include <memory>
 #include <vector>
 
 #include "Vertex.h"
@@ -18,7 +19,7 @@ struct MeshData
 {
     std::vector<Vertex> vertices;
     std::vector<u32> indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 };
 
 namespace InternalMeshData
@@ -26,7 +27,7 @@ namespace InternalMeshData
 
 inline MeshData cube;
 inline MeshData big_cube;
-inline Texture white_texture;
+inline std::shared_ptr<Texture> white_texture;
 
 void light_initialize(); // FIXME: Move that to the initialize() function when it works on DX11
 void initialize();

--- a/src/Grass.cpp
+++ b/src/Grass.cpp
@@ -74,9 +74,9 @@ std::shared_ptr<Mesh> Grass::create_blade() const
         0, 2, 3
     };
 
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
-    std::vector<Texture> diffuse_maps = {};
+    std::vector<std::shared_ptr<Texture>> diffuse_maps = {};
     TextureSettings texture_settings = {};
     texture_settings.wrap_mode_x = TextureWrapMode::ClampToEdge;
     texture_settings.wrap_mode_y = TextureWrapMode::ClampToEdge;

--- a/src/Grass.cpp
+++ b/src/Grass.cpp
@@ -2,6 +2,7 @@
 
 #include "Globals.h"
 #include "MeshFactory.h"
+#include "ResourceManager.h"
 #include "TextureLoader.h"
 
 std::shared_ptr<Grass> Grass::create()
@@ -82,9 +83,9 @@ std::shared_ptr<Mesh> Grass::create_blade() const
     texture_settings.wrap_mode_y = TextureWrapMode::ClampToEdge;
 
     if (!m_diffuse_texture_path.empty())
-        diffuse_maps.emplace_back(TextureLoader::get_instance()->load_texture(m_diffuse_texture_path, TextureType::Diffuse, texture_settings));
+        diffuse_maps.emplace_back(ResourceManager::get_instance().load_texture(m_diffuse_texture_path, TextureType::Diffuse, texture_settings));
 
     textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
 
-    return MeshFactory::create(vertices, indices, textures, m_draw_type, material);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), m_diffuse_texture_path, vertices, indices, textures, m_draw_type, material);
 }

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -8,9 +8,9 @@
 #include "Texture.h"
 #include "Vertex.h"
 
-Mesh::Mesh(std::vector<Vertex> const& vertices, std::vector<u32> const& indices, std::vector<Texture> const& textures,
+Mesh::Mesh(std::vector<Vertex> const& vertices, std::vector<u32> const& indices, std::vector<std::shared_ptr<Texture>> const& textures,
            DrawType const draw_type, std::shared_ptr<Material> const& material, DrawFunctionType const draw_function)
-    : m_vertices(vertices), m_indices(indices), m_textures(textures), material(material), m_draw_type(draw_type), m_draw_function(draw_function)
+    : material(material), m_vertices(vertices), m_indices(indices), m_textures(textures), m_draw_type(draw_type), m_draw_function(draw_function)
 {
 }
 

--- a/src/Mesh.h
+++ b/src/Mesh.h
@@ -30,14 +30,14 @@ public:
     std::shared_ptr<Material> material;
 
 protected:
-    Mesh(std::vector<Vertex> const& vertices, std::vector<u32> const& indices, std::vector<Texture> const& textures,
+    Mesh(std::vector<Vertex> const& vertices, std::vector<u32> const& indices, std::vector<std::shared_ptr<Texture>> const& textures,
          DrawType const draw_type, std::shared_ptr<Material> const& material, DrawFunctionType const draw_function);
 
     [[nodiscard]] BoundingBox calculate_adjusted_bounding_box(glm::mat4 const& model_matrix) const;
 
     std::vector<Vertex> m_vertices;
     std::vector<u32> m_indices;
-    std::vector<Texture> m_textures;
+    std::vector<std::shared_ptr<Texture>> m_textures;
 
     DrawType m_draw_type;
     DrawFunctionType m_draw_function;

--- a/src/MeshDX11.cpp
+++ b/src/MeshDX11.cpp
@@ -117,8 +117,8 @@ void MeshDX11::bind_textures() const
 
     for (u32 i = 0; i < m_textures.size(); ++i)
     {
-        device_context->PSSetShaderResources(0, 1, &m_textures[i].shader_resource_view);
-        device_context->PSSetSamplers(0, 1, &m_textures[i].image_sampler_state);
+        device_context->PSSetShaderResources(i, 1, &m_textures[i].shader_resource_view);
+        device_context->PSSetSamplers(i, 1, &m_textures[i].image_sampler_state);
     }
 }
 
@@ -127,9 +127,11 @@ void MeshDX11::unbind_textures() const
     auto const device_context = RendererDX11::get_instance_dx11()->get_device_context();
 
     ID3D11ShaderResourceView* null_shader_resource_view = nullptr;
+    ID3D11SamplerState* null_sampler_state = nullptr;
+
     for (u32 i = 0; i < m_textures.size(); ++i)
     {
-        device_context->PSSetShaderResources(0, 1, &null_shader_resource_view);
-        device_context->PSSetSamplers(0, 1, &m_textures[i].image_sampler_state);
+        device_context->PSSetShaderResources(i, 1, &null_shader_resource_view);
+        device_context->PSSetSamplers(i, 1, &null_sampler_state);
     }
 }

--- a/src/MeshDX11.cpp
+++ b/src/MeshDX11.cpp
@@ -8,7 +8,7 @@
 #include <TextureLoaderDX11.h>
 
 MeshDX11::MeshDX11(AK::Badge<MeshFactory>, std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-                   std::vector<Texture> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
+                   std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
                    DrawFunctionType const draw_function) : Mesh(vertices, indices, textures, draw_type, material, draw_function)
 {
     switch (draw_type)
@@ -69,19 +69,19 @@ MeshDX11::~MeshDX11()
     // FIXME: Managing lifetime of models and textures should be handled in ResourceManager
     for (auto const& texture : m_textures)
     {
-        if (texture.image_sampler_state)
+        if (texture->image_sampler_state)
         {
-            texture.image_sampler_state->Release();
+            texture->image_sampler_state->Release();
         }
 
-        if (texture.shader_resource_view)
+        if (texture->shader_resource_view)
         {
-            texture.shader_resource_view->Release();
+            texture->shader_resource_view->Release();
         }
 
-        if (texture.texture_2d)
+        if (texture->texture_2d)
         {
-            texture.texture_2d->Release();
+            texture->texture_2d->Release();
         }
     }
 
@@ -117,8 +117,8 @@ void MeshDX11::bind_textures() const
 
     for (u32 i = 0; i < m_textures.size(); ++i)
     {
-        device_context->PSSetShaderResources(i, 1, &m_textures[i].shader_resource_view);
-        device_context->PSSetSamplers(i, 1, &m_textures[i].image_sampler_state);
+        device_context->PSSetShaderResources(i, 1, &m_textures[i]->shader_resource_view);
+        device_context->PSSetSamplers(i, 1, &m_textures[i]->image_sampler_state);
     }
 }
 

--- a/src/MeshDX11.h
+++ b/src/MeshDX11.h
@@ -11,7 +11,7 @@ class MeshDX11 final : public Mesh
 {
 public:
     MeshDX11(AK::Badge<MeshFactory>, std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-             std::vector<Texture> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
+             std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
              DrawFunctionType const draw_function);
 
     MeshDX11(MeshDX11&& mesh) noexcept;

--- a/src/MeshFactory.cpp
+++ b/src/MeshFactory.cpp
@@ -5,7 +5,7 @@
 #include "Renderer.h"
 
 std::shared_ptr<Mesh> MeshFactory::create(std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-                                          std::vector<Texture> const& textures, DrawType const draw_type,
+                                          std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type,
                                           std::shared_ptr<Material> const& material, DrawFunctionType const draw_function)
 {
     switch (Renderer::renderer_api)

--- a/src/MeshFactory.h
+++ b/src/MeshFactory.h
@@ -13,7 +13,7 @@ class MeshFactory
 {
 public:
     static std::shared_ptr<Mesh> create(std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-                                        std::vector<Texture> const& textures, DrawType const draw_type,
+                                        std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type,
                                         std::shared_ptr<Material> const& material,
                                         DrawFunctionType const draw_function = DrawFunctionType::Indexed);
 };

--- a/src/MeshFactory.h
+++ b/src/MeshFactory.h
@@ -9,9 +9,14 @@
 #include "Vertex.h"
 #include "AK/Types.h"
 
+class ResourceManager;
+
 class MeshFactory
 {
 public:
+    friend class ResourceManager;
+
+private:
     static std::shared_ptr<Mesh> create(std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
                                         std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type,
                                         std::shared_ptr<Material> const& material,

--- a/src/MeshGL.cpp
+++ b/src/MeshGL.cpp
@@ -7,7 +7,7 @@
 #include "Texture.h"
 
 MeshGL::MeshGL(AK::Badge<MeshFactory>, std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-               std::vector<Texture> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
+               std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
                DrawFunctionType const draw_function):
     Mesh(vertices, indices, textures, draw_type, material, draw_function)
 {
@@ -96,7 +96,7 @@ MeshGL::~MeshGL()
 {
     for (auto const& texture : m_textures)
     {
-        glDeleteTextures(1, &texture.id);
+        glDeleteTextures(1, &texture->id);
     }
 
     m_vertices.clear();
@@ -170,24 +170,24 @@ void MeshGL::bind_textures() const
         std::string number;
         std::string name = "material.";
 
-        if (m_textures[i].type == TextureType::Diffuse)
+        if (m_textures[i]->type == TextureType::Diffuse)
         {
             name += "texture_diffuse";
             number = std::to_string(diffuse_number++);
         }
-        else if (m_textures[i].type == TextureType::Specular)
+        else if (m_textures[i]->type == TextureType::Specular)
         {
             name += "texture_specular";
             number = std::to_string(specular_number++);
         }
-        else if (m_textures[i].type == TextureType::Heightmap)
+        else if (m_textures[i]->type == TextureType::Heightmap)
         {
             name += "texture_height";
             number = std::to_string(height_number++);
         }
 
         material->shader->set_int(name + number, i);
-        glBindTexture(GL_TEXTURE_2D, m_textures[i].id);
+        glBindTexture(GL_TEXTURE_2D, m_textures[i]->id);
     }
 
     if (m_textures.empty())
@@ -196,7 +196,7 @@ void MeshGL::bind_textures() const
 
         material->shader->set_int("material.texture_diffuse1", 0);
 
-        glBindTexture(GL_TEXTURE_2D, InternalMeshData::white_texture.id);
+        glBindTexture(GL_TEXTURE_2D, InternalMeshData::white_texture->id);
     }
 }
 

--- a/src/MeshGL.h
+++ b/src/MeshGL.h
@@ -8,7 +8,7 @@ class MeshGL final : public Mesh
 {
 public:
     MeshGL(AK::Badge<MeshFactory>, std::vector<Vertex> const& vertices, std::vector<u32> const& indices,
-           std::vector<Texture> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
+           std::vector<std::shared_ptr<Texture>> const& textures, DrawType const draw_type, std::shared_ptr<Material> const& material,
            DrawFunctionType const draw_function);
 
     MeshGL(MeshGL&& mesh) noexcept;

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -187,7 +187,7 @@ std::shared_ptr<Mesh> Model::proccess_mesh(aiMesh const* mesh, aiScene const* sc
 {
     std::vector<Vertex> vertices;
     std::vector<u32> indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
     for (u32 i = 0; i < mesh->mNumVertices; ++i)
     {
@@ -223,18 +223,18 @@ std::shared_ptr<Mesh> Model::proccess_mesh(aiMesh const* mesh, aiScene const* sc
 
     aiMaterial const* assimp_material = scene->mMaterials[mesh->mMaterialIndex];
 
-    std::vector<Texture> diffuse_maps = load_material_textures(assimp_material, aiTextureType_DIFFUSE, TextureType::Diffuse);
+    std::vector<std::shared_ptr<Texture>> diffuse_maps = load_material_textures(assimp_material, aiTextureType_DIFFUSE, TextureType::Diffuse);
     textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
 
-    std::vector<Texture> specular_maps = load_material_textures(assimp_material, aiTextureType_SPECULAR, TextureType::Specular);
+    std::vector<std::shared_ptr<Texture>> specular_maps = load_material_textures(assimp_material, aiTextureType_SPECULAR, TextureType::Specular);
     textures.insert(textures.end(), specular_maps.begin(), specular_maps.end());
 
     return MeshFactory::create(vertices, indices, textures, m_draw_type, material);
 }
 
-std::vector<Texture> Model::load_material_textures(aiMaterial const* material, aiTextureType const type, TextureType const type_name)
+std::vector<std::shared_ptr<Texture>> Model::load_material_textures(aiMaterial const* material, aiTextureType const type, TextureType const type_name)
 {
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
     u32 const material_count = material->GetTextureCount(type);
     for (u32 i = 0; i < material_count; ++i)
@@ -243,9 +243,9 @@ std::vector<Texture> Model::load_material_textures(aiMaterial const* material, a
         material->GetTexture(type, i, &str);
 
         bool is_already_loaded = false;
-        for (const auto& loaded_texture : m_loaded_textures)
+        for (auto const& loaded_texture : m_loaded_textures)
         {
-            if (std::strcmp(loaded_texture.path.data(), str.C_Str()) == 0)
+            if (std::strcmp(loaded_texture->path.data(), str.C_Str()) == 0)
             {
                 textures.push_back(loaded_texture);
                 is_already_loaded = true;
@@ -262,7 +262,7 @@ std::vector<Texture> Model::load_material_textures(aiMaterial const* material, a
         TextureSettings settings = {};
         settings.flip_vertically = false;
 
-        Texture texture = TextureLoader::get_instance()->load_texture(file_path, type_name, settings);
+        std::shared_ptr<Texture> texture = TextureLoader::get_instance()->load_texture(file_path, type_name, settings);
         textures.push_back(texture);
         m_loaded_textures.push_back(texture);
     }

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -7,14 +7,12 @@
 
 #include <imgui.h>
 
-#include <glad/glad.h>
-
 #include "Entity.h"
 #include "Globals.h"
 #include "Mesh.h"
 #include "MeshFactory.h"
+#include "ResourceManager.h"
 #include "Texture.h"
-#include "TextureLoader.h"
 #include "Vertex.h"
 #include "AK/Types.h"
 
@@ -98,11 +96,6 @@ BoundingBox Model::get_adjusted_bounding_box(glm::mat4 const& model_matrix) cons
         return m_meshes[0]->get_adjusted_bounding_box(model_matrix);
 
     return {};
-}
-
-Model::Model(std::string const& model_path, std::shared_ptr<Material> const& material)
-    : Drawable(material), model_path(model_path)
-{
 }
 
 Model::Model(std::shared_ptr<Material> const& material) : Drawable(material)
@@ -229,7 +222,7 @@ std::shared_ptr<Mesh> Model::proccess_mesh(aiMesh const* mesh, aiScene const* sc
     std::vector<std::shared_ptr<Texture>> specular_maps = load_material_textures(assimp_material, aiTextureType_SPECULAR, TextureType::Specular);
     textures.insert(textures.end(), specular_maps.begin(), specular_maps.end());
 
-    return MeshFactory::create(vertices, indices, textures, m_draw_type, material);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), model_path, vertices, indices, textures, m_draw_type, material);
 }
 
 std::vector<std::shared_ptr<Texture>> Model::load_material_textures(aiMaterial const* material, aiTextureType const type, TextureType const type_name)
@@ -262,7 +255,7 @@ std::vector<std::shared_ptr<Texture>> Model::load_material_textures(aiMaterial c
         TextureSettings settings = {};
         settings.flip_vertically = false;
 
-        std::shared_ptr<Texture> texture = TextureLoader::get_instance()->load_texture(file_path, type_name, settings);
+        std::shared_ptr<Texture> texture = ResourceManager::get_instance().load_texture(file_path, type_name, settings);
         textures.push_back(texture);
         m_loaded_textures.push_back(texture);
     }

--- a/src/Model.h
+++ b/src/Model.h
@@ -53,8 +53,8 @@ private:
     void load_model(std::string const& path);
     void proccess_node(aiNode const* node, aiScene const* scene);
     std::shared_ptr<Mesh> proccess_mesh(aiMesh const* mesh, aiScene const* scene);
-    std::vector<Texture> load_material_textures(aiMaterial const* material, aiTextureType type, TextureType const type_name);
+    std::vector<std::shared_ptr<Texture>> load_material_textures(aiMaterial const* material, aiTextureType type, TextureType const type_name);
 
     std::string m_directory;
-    std::vector<Texture> m_loaded_textures;
+    std::vector<std::shared_ptr<Texture>> m_loaded_textures;
 };

--- a/src/Model.h
+++ b/src/Model.h
@@ -4,14 +4,14 @@
 
 #include <assimp/material.h>
 
+#include "Texture.h"
+#include "Mesh.h"
+#include "AK/Badge.h"
+
 struct aiMaterial;
 struct aiMesh;
 struct aiScene;
 struct aiNode;
-
-#include "Texture.h"
-#include "Mesh.h"
-#include "AK/Badge.h"
 
 class Model : public Drawable
 {
@@ -42,14 +42,12 @@ public:
     std::string model_path = "";
 
 protected:
-    explicit Model(std::string const& model_path, std::shared_ptr<Material> const& material);
     explicit Model(std::shared_ptr<Material> const& material);
 
     DrawType m_draw_type = DrawType::Triangles;
     std::vector<std::shared_ptr<Mesh>> m_meshes = {};
 
 private:
-
     void load_model(std::string const& path);
     void proccess_node(aiNode const* node, aiScene const* scene);
     std::shared_ptr<Mesh> proccess_mesh(aiMesh const* mesh, aiScene const* scene);

--- a/src/RendererDX11.cpp
+++ b/src/RendererDX11.cpp
@@ -10,6 +10,8 @@
 
 #include <array>
 
+#include "ResourceManager.h"
+
 std::shared_ptr<RendererDX11> RendererDX11::create()
 {
     auto renderer = std::make_shared<RendererDX11>(AK::Badge<RendererDX11> {});
@@ -60,7 +62,7 @@ std::shared_ptr<RendererDX11> RendererDX11::create()
     renderer->m_shadow_map_viewport = create_viewport(SHADOW_MAP_SIZE, SHADOW_MAP_SIZE);
 
     renderer->setup_shadow_mapping();
-    renderer->m_shadow_shader = ShaderFactory::create("./res/shaders/shadow_mapping.hlsl", "./res/shaders/shadow_mapping.hlsl");
+    renderer->m_shadow_shader = ResourceManager::get_instance().load_shader("./res/shaders/shadow_mapping.hlsl", "./res/shaders/shadow_mapping.hlsl");
 
     return renderer;
 }

--- a/src/RendererGL.cpp
+++ b/src/RendererGL.cpp
@@ -6,6 +6,7 @@
 #include "Camera.h"
 #include "Entity.h"
 #include "MeshGL.h"
+#include "ResourceManager.h"
 #include "ShaderFactory.h"
 #include "Skybox.h"
 #include "TextureLoaderGL.h"
@@ -20,7 +21,7 @@ std::shared_ptr<RendererGL> RendererGL::create()
 
     TextureLoaderGL::create();
 
-    renderer->m_frustum_culling_shader = ShaderFactory::create("./res/shaders/frustum_culling.glsl");
+    renderer->m_frustum_culling_shader = ResourceManager::get_instance().load_shader("./res/shaders/frustum_culling.glsl");
 
     return renderer;
 }

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -1,0 +1,148 @@
+#include "ResourceManager.h"
+
+#include <iostream>
+#include <sstream>
+
+#include "MeshFactory.h"
+#include "ShaderFactory.h"
+#include "TextureLoader.h"
+
+ResourceManager& ResourceManager::get_instance()
+{
+    static ResourceManager instance;
+    return instance;
+}
+
+std::shared_ptr<Texture> ResourceManager::load_texture(std::string const& path, TextureType const type, TextureSettings const& settings)
+{
+    std::string const& key = path; // No need to even call generate_key()
+    std::shared_ptr<Texture> resource_ptr = get_from_vector<Texture>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = TextureLoader::get_instance()->load_texture(path, type, settings);
+    m_textures.emplace_back(resource_ptr);
+    names_to_textures.insert(std::pair<std::string, u16>(key, m_textures.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Texture> ResourceManager::load_cubemap(std::vector<std::string> const& paths, TextureType const type,
+                                                       TextureSettings const& settings)
+{
+    std::stringstream stream;
+    stream << paths[0] << paths[1] << paths[2] << paths[3] << paths[4] << paths[5];
+    std::string const& key = generate_key(stream);
+    std::shared_ptr<Texture> resource_ptr = get_from_vector<Texture>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = TextureLoader::get_instance()->load_cubemap(paths, type, settings);
+    m_textures.emplace_back(resource_ptr);
+    names_to_textures.insert(std::make_pair(key, m_textures.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Shader> ResourceManager::load_shader(std::string const& compute_path)
+{
+    std::stringstream stream;
+    stream << compute_path;
+    std::string const& key = generate_key(stream);
+    auto resource_ptr = get_from_vector<Shader>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = ShaderFactory::create(compute_path);
+    m_shaders.emplace_back(resource_ptr);
+    names_to_shaders.insert(std::make_pair(key, m_shaders.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Shader> ResourceManager::load_shader(std::string const& vertex_path, std::string const& fragment_path)
+{
+    std::stringstream stream;
+    stream << vertex_path << fragment_path;
+    std::string const& key = generate_key(stream);
+
+    auto resource_ptr = get_from_vector<Shader>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = ShaderFactory::create(vertex_path, fragment_path);
+    m_shaders.emplace_back(resource_ptr);
+    names_to_shaders.insert(std::make_pair(key, m_shaders.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Shader> ResourceManager::load_shader(std::string const& vertex_path, std::string const& fragment_path,
+                                                     std::string const& geometry_path)
+{
+    std::stringstream stream;
+    stream << vertex_path << fragment_path << geometry_path;
+    std::string const& key = generate_key(stream);
+
+    auto resource_ptr = get_from_vector<Shader>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = ShaderFactory::create(vertex_path, fragment_path, geometry_path);
+    m_shaders.emplace_back(resource_ptr);
+    names_to_shaders.insert(std::make_pair(key, m_shaders.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Shader> ResourceManager::load_shader(std::string const& vertex_path,
+                                                     std::string const& tessellation_control_path,
+                                                     std::string const& tessellation_evaluation_path,
+                                                     std::string const& fragment_path)
+{
+    std::stringstream stream;
+    stream << vertex_path << tessellation_control_path << tessellation_evaluation_path << fragment_path;
+    std::string const& key = generate_key(stream);
+
+    auto resource_ptr = get_from_vector<Shader>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = ShaderFactory::create(vertex_path, tessellation_control_path, tessellation_evaluation_path, fragment_path);
+    m_shaders.emplace_back(resource_ptr);
+    names_to_shaders.insert(std::make_pair(key, m_shaders.size() - 1));
+
+    return resource_ptr;
+}
+
+std::shared_ptr<Mesh> ResourceManager::load_mesh(u32 const array_id, std::string const& name, std::vector<Vertex> const& vertices,
+                                                 std::vector<u32> const& indices, std::vector<std::shared_ptr<Texture>> const& textures,
+                                                 DrawType const draw_type, std::shared_ptr<Material> const& material,
+                                                 DrawFunctionType const draw_function)
+{
+    std::stringstream stream;
+    stream << name << array_id;
+    std::string const& key = generate_key(stream);
+
+    auto resource_ptr = get_from_vector<Mesh>(key);
+
+    if (resource_ptr != nullptr)
+        return resource_ptr;
+
+    resource_ptr = MeshFactory::create(vertices, indices, textures, draw_type, material, draw_function);
+    m_meshes.emplace_back(resource_ptr);
+    names_to_meshes.insert(std::make_pair(key, m_meshes.size() - 1));
+
+    return resource_ptr;
+}
+
+std::string ResourceManager::generate_key(std::stringstream const& stream) const
+{
+    return stream.str();
+}

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "Mesh.h"
+#include "Model.h"
+#include "Shader.h"
+#include "Texture.h"
+#include "AK/Types.h"
+
+// How ResourceManager works:
+//
+// 1. Generate key (each function may have its own implementation) and save it in a local variable.
+// 2. Call template method get_from_vector() specifying desired <TYPE> and providing the key. It will return either nullptr or a valid resource.
+// 3a. If a valid resource is returned by get_from_vector(), you've got your resource!
+// 3b. If a nullptr is returned by get_from_vector(), an internal loading function is called and the returned value is added to vector along with key and ID to the map.
+class ResourceManager
+{
+public:
+    ResourceManager(ResourceManager const&) = delete;
+    void operator=(ResourceManager const&) = delete;
+    ~ResourceManager() = default;
+
+    static ResourceManager& get_instance();
+
+    std::shared_ptr<Texture> load_texture(std::string const& path, TextureType const type, TextureSettings const& settings = {});
+    std::shared_ptr<Texture> load_cubemap(std::vector<std::string> const& paths, TextureType const type, TextureSettings const& settings = {});
+
+    std::shared_ptr<Shader> load_shader(std::string const& compute_path);
+    std::shared_ptr<Shader> load_shader(std::string const& vertex_path, std::string const& fragment_path);
+    std::shared_ptr<Shader> load_shader(std::string const& vertex_path, std::string const& fragment_path, std::string const& geometry_path);
+    std::shared_ptr<Shader> load_shader(std::string const& vertex_path, std::string const& tessellation_control_path,
+                                        std::string const& tessellation_evaluation_path, std::string const& fragment_path);
+
+    std::shared_ptr<Mesh> load_mesh(u32 const array_id, std::string const& name, std::vector<Vertex> const& vertices,
+                                    std::vector<u32> const& indices, std::vector<std::shared_ptr<Texture>> const& textures,
+                                    DrawType const draw_type, std::shared_ptr<Material> const& material,
+                                    DrawFunctionType const draw_function = DrawFunctionType::Indexed);
+
+private:
+    ResourceManager() = default;
+
+    template <typename T>
+    std::shared_ptr<T> get_from_vector(std::string const& key)
+    {
+        i32 id = -1;
+
+        // TODO: This can be automatized by extending EngineHeaderTool.
+        // For now it's good enough.
+        if constexpr (std::is_same_v<T, Texture>)
+        {
+            auto const it = names_to_textures.find(key);
+            if (it != names_to_textures.end())
+            {
+                id = it->second;
+                return m_textures[id];
+            }
+        }
+        else if constexpr (std::is_same_v<T, Mesh>)
+        {
+            auto const it = names_to_meshes.find(key);
+            if (it != names_to_meshes.end())
+            {
+                id = it->second;
+                return m_meshes[id];
+            }
+        }
+        else if constexpr (std::is_same_v<T, Shader>)
+        {
+            auto const it = names_to_shaders.find(key);
+            if (it != names_to_shaders.end())
+            {
+                id = it->second;
+                return m_shaders[id];
+            }
+        }
+
+        return nullptr;
+    }
+
+    [[nodiscard]] std::string generate_key(std::stringstream const& stream) const;
+
+    // NOTE: RM currently doesn't allow unloadading any resources that were previously loaded.
+    std::vector<std::shared_ptr<Texture>> m_textures = {};
+    std::vector<std::shared_ptr<Mesh>> m_meshes = {};
+    std::vector<std::shared_ptr<Shader>> m_shaders = {};
+
+    // KEYS (usually generated from path and optionally additional data) | INDICES, in a respective vector.
+    std::unordered_map<std::string, u16> names_to_textures = {};
+    std::unordered_map<std::string, u16> names_to_meshes = {};
+    std::unordered_map<std::string, u16> names_to_shaders = {};
+
+    inline static std::shared_ptr<ResourceManager> m_instance;
+};

--- a/src/ScreenText.cpp
+++ b/src/ScreenText.cpp
@@ -1,11 +1,12 @@
 #include "ScreenText.h"
 #include "RendererDX11.h"
+#include "ResourceManager.h"
 #include "ShaderFactory.h"
 #include <glm/gtc/type_ptr.inl>
 
 std::shared_ptr<ScreenText> ScreenText::create()
 {
-    auto const ui_shader = ShaderFactory::create("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
+    auto const ui_shader = ResourceManager::get_instance().load_shader("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
     auto const ui_material = Material::create(ui_shader);
     auto text = std::make_shared<ScreenText>(AK::Badge<ScreenText> {}, ui_material);
 
@@ -28,7 +29,7 @@ ScreenText::ScreenText(AK::Badge<ScreenText>, std::wstring const& content, glm::
     : Drawable(nullptr), text(content), position(position), font_size(font_size), color(color),
       flags(flags | FW1_RESTORESTATE) // Restore DX11 state by default
 {
-    auto const ui_shader = ShaderFactory::create("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
+    auto const ui_shader = ResourceManager::get_instance().load_shader("./res/shaders/ui.hlsl", "./res/shaders/ui.hlsl");
     auto const ui_material = Material::create(ui_shader);
     material = ui_material;
 }

--- a/src/ShaderFactory.h
+++ b/src/ShaderFactory.h
@@ -1,15 +1,24 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "Shader.h"
+
+class ResourceManager;
 
 class ShaderFactory
 {
 public:
+    ShaderFactory() = delete;
+
+private:
     static std::shared_ptr<Shader> create(std::string const& compute_path);
     static std::shared_ptr<Shader> create(std::string const& vertex_path, std::string const& fragment_path);
-    static std::shared_ptr<Shader> create(std::string const& vertex_path, std::string const& fragment_path, std::string const& geometry_path);
+    static std::shared_ptr<Shader> create(std::string const& vertex_path, std::string const& fragment_path,
+                                          std::string const& geometry_path);
     static std::shared_ptr<Shader> create(std::string const& vertex_path, std::string const& tessellation_control_path,
                                           std::string const& tessellation_evaluation_path, std::string const& fragment_path);
+
+    friend class ResourceManager;
 };

--- a/src/Skybox.cpp
+++ b/src/Skybox.cpp
@@ -32,8 +32,7 @@ void Skybox::load_textures()
         false
     };
 
-    auto const [id, width, height, number_of_components, type, texture_2d, resource, sampler, path] = TextureLoader::get_instance()->load_cubemap(m_face_paths, TextureType::None, texture_settings);
-    m_texture_id = id;
+    m_texture = TextureLoader::get_instance()->load_cubemap(m_face_paths, TextureType::None, texture_settings);
 }
 
 void Skybox::set_instance(std::shared_ptr<Skybox> const& skybox)

--- a/src/Skybox.cpp
+++ b/src/Skybox.cpp
@@ -5,7 +5,7 @@
 #include <glad/glad.h>
 
 #include "Globals.h"
-#include "TextureLoader.h"
+#include "ResourceManager.h"
 
 Skybox::Skybox(std::shared_ptr<Material> const& material, std::vector<std::string> const& face_paths) : Drawable(material), m_face_paths(face_paths)
 {
@@ -32,7 +32,7 @@ void Skybox::load_textures()
         false
     };
 
-    m_texture = TextureLoader::get_instance()->load_cubemap(m_face_paths, TextureType::None, texture_settings);
+    m_texture = ResourceManager::get_instance().load_cubemap(m_face_paths, TextureType::None, texture_settings);
 }
 
 void Skybox::set_instance(std::shared_ptr<Skybox> const& skybox)

--- a/src/Skybox.h
+++ b/src/Skybox.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "Drawable.h"
+#include "Texture.h"
 #include "Vertex.h"
 #include "Serialization.h"
 
@@ -25,7 +26,7 @@ public:
     void operator=(Skybox const&) = delete;
 
 protected:
-    u32 m_texture_id = 0;
+    std::shared_ptr<Texture> m_texture = nullptr;
 
 private:
     void virtual bind_texture() const = 0;

--- a/src/SkyboxGL.cpp
+++ b/src/SkyboxGL.cpp
@@ -17,7 +17,7 @@ void SkyboxGL::bind()
 
 void SkyboxGL::draw() const
 {
-    if (m_texture_id == 0)
+    if (m_texture->id == 0)
         return;
 
     GLint depth_func_previous_value;
@@ -29,7 +29,7 @@ void SkyboxGL::draw() const
 
     glActiveTexture(GL_TEXTURE0);
     material->shader->set_int("skybox", 0);
-    glBindTexture(GL_TEXTURE_CUBE_MAP, m_texture_id);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_texture->id);
 
     // Draw mesh
     glDrawArrays(GL_TRIANGLES, 0, 36);
@@ -45,7 +45,7 @@ void SkyboxGL::draw() const
 
 void SkyboxGL::bind_texture() const
 {
-    glBindTexture(GL_TEXTURE_CUBE_MAP, m_texture_id);
+    glBindTexture(GL_TEXTURE_CUBE_MAP, m_texture->id);
 }
 
 void SkyboxGL::create_cube()

--- a/src/Sphere.cpp
+++ b/src/Sphere.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<Mesh> Sphere::create_sphere() const
 
     std::vector<Vertex> vertices;
     std::vector<u32> indices;
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
     if (use_geometry_shader)
     {
@@ -84,7 +84,7 @@ std::shared_ptr<Mesh> Sphere::create_sphere() const
         indices.push_back(1);
         indices.push_back(2);
 
-        std::vector<Texture> diffuse_maps = { TextureLoader::get_instance()->load_texture(texture_path, TextureType::Diffuse) };
+        std::vector diffuse_maps = { TextureLoader::get_instance()->load_texture(texture_path, TextureType::Diffuse) };
         textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
 
         material->radius_multiplier = radius;
@@ -138,7 +138,7 @@ std::shared_ptr<Mesh> Sphere::create_sphere() const
 
     if (!texture_path.empty())
     {
-        std::vector<Texture> diffuse_maps = { TextureLoader::get_instance()->load_texture(texture_path, TextureType::Diffuse) };
+        std::vector diffuse_maps = { TextureLoader::get_instance()->load_texture(texture_path, TextureType::Diffuse) };
         textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
     }
 

--- a/src/Sphere.h
+++ b/src/Sphere.h
@@ -7,7 +7,7 @@ class Sphere final : public Model
 public:
     static std::shared_ptr<Sphere> create();
     static std::shared_ptr<Sphere> create(float radius, u32 sectors, u32 stacks, std::string const& texture_path, std::shared_ptr<Material> const& material);
-
+    virtual void start() override;
     explicit Sphere(AK::Badge<Sphere>, std::shared_ptr<Material> const& material);
     Sphere(AK::Badge<Sphere>, float radius, u32 sectors, u32 stacks, std::string const& texture_path, std::shared_ptr<Material> const& material);
 

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -75,9 +75,9 @@ std::shared_ptr<Mesh> Sprite::create_sprite() const
         0, 2, 3
     };
 
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
 
-    std::vector<Texture> diffuse_maps = {};
+    std::vector<std::shared_ptr<Texture>> diffuse_maps = {};
     TextureSettings texture_settings = {};
     texture_settings.wrap_mode_x = TextureWrapMode::ClampToEdge;
     texture_settings.wrap_mode_y = TextureWrapMode::ClampToEdge;

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -2,6 +2,7 @@
 
 #include "Globals.h"
 #include "MeshFactory.h"
+#include "ResourceManager.h"
 #include "TextureLoader.h"
 
 std::shared_ptr<Sprite> Sprite::create()
@@ -83,9 +84,9 @@ std::shared_ptr<Mesh> Sprite::create_sprite() const
     texture_settings.wrap_mode_y = TextureWrapMode::ClampToEdge;
 
     if (!diffuse_texture_path.empty())
-        diffuse_maps.emplace_back(TextureLoader::get_instance()->load_texture(diffuse_texture_path, TextureType::Diffuse, texture_settings));
+        diffuse_maps.emplace_back(ResourceManager::get_instance().load_texture(diffuse_texture_path, TextureType::Diffuse, texture_settings));
 
     textures.insert(textures.end(), diffuse_maps.begin(), diffuse_maps.end());
 
-    return MeshFactory::create(vertices, indices, textures, m_draw_type, material);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), diffuse_texture_path, vertices, indices, textures, m_draw_type, material);
 }

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -76,18 +76,18 @@ std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map_gpu() const
         false,
     };
 
-    Texture const heightmap = TextureLoader::get_instance()->load_texture(m_height_map_path, TextureType::Heightmap, texture_settings);
+    std::shared_ptr<Texture> const heightmap = TextureLoader::get_instance()->load_texture(m_height_map_path, TextureType::Heightmap, texture_settings);
 
-    if (heightmap.id == 0)
+    if (heightmap->id == 0)
     {
         std::cout << "Height map failed to load at path: " << m_height_map_path << '\n';
         return MeshFactory::create({}, {}, {}, m_draw_type, material);
     }
 
-    i32 const width = heightmap.width;
-    i32 const height = heightmap.height;
+    i32 const width = heightmap->width;
+    i32 const height = heightmap->height;
 
-    std::vector<Texture> textures;
+    std::vector<std::shared_ptr<Texture>> textures;
     textures.emplace_back(heightmap);
 
     u32 constexpr resolution = 20;

--- a/src/Terrain.cpp
+++ b/src/Terrain.cpp
@@ -4,7 +4,7 @@
 #include <stb_image.h>
 
 #include "MeshFactory.h"
-#include "TextureLoader.h"
+#include "ResourceManager.h"
 
 std::shared_ptr<Terrain> Terrain::create(std::shared_ptr<Material> const& material, bool const use_gpu, std::string const& height_map_path)
 {
@@ -76,12 +76,12 @@ std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map_gpu() const
         false,
     };
 
-    std::shared_ptr<Texture> const heightmap = TextureLoader::get_instance()->load_texture(m_height_map_path, TextureType::Heightmap, texture_settings);
+    std::shared_ptr<Texture> const heightmap = ResourceManager::get_instance().load_texture(m_height_map_path, TextureType::Heightmap, texture_settings);
 
     if (heightmap->id == 0)
     {
         std::cout << "Height map failed to load at path: " << m_height_map_path << '\n';
-        return MeshFactory::create({}, {}, {}, m_draw_type, material);
+        return ResourceManager::get_instance().load_mesh(m_meshes.size(), m_height_map_path, {}, {}, {}, m_draw_type, material);
     }
 
     i32 const width = heightmap->width;
@@ -152,7 +152,7 @@ std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map_gpu() const
         }
     }
 
-    return MeshFactory::create(vertices, {}, textures, m_draw_type, material, DrawFunctionType::NotIndexed);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), m_height_map_path, vertices, {}, textures, m_draw_type, material, DrawFunctionType::NotIndexed);
 }
 
 std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map()
@@ -166,7 +166,7 @@ std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map()
     {
         std::cout << "Height map failed to load at path: " << m_height_map_path << '\n';
         stbi_image_free(data);
-        return MeshFactory::create({}, {}, {}, m_draw_type, material);
+        return ResourceManager::get_instance().load_mesh(m_meshes.size(), m_height_map_path, {}, {}, {}, m_draw_type, material);
     }
 
     std::vector<Vertex> vertices = {};
@@ -206,5 +206,5 @@ std::shared_ptr<Mesh> Terrain::create_terrain_from_height_map()
     m_strips_count = height - 1;
     m_vertices_per_strip = width * 2;
 
-    return MeshFactory::create(vertices, indices, {}, m_draw_type, material);
+    return ResourceManager::get_instance().load_mesh(m_meshes.size(), m_height_map_path, vertices, indices, {}, m_draw_type, material);
 }

--- a/src/TextureLoader.cpp
+++ b/src/TextureLoader.cpp
@@ -2,17 +2,18 @@
 
 #include <cassert>
 
-Texture TextureLoader::load_texture(std::string const& path, TextureType const type, TextureSettings const& settings)
+std::shared_ptr<Texture> TextureLoader::load_texture(std::string const &path, TextureType const type,
+                                                     TextureSettings const &settings)
 {
     auto const [id, width, height, number_of_components, texture_2d, shader_resource_view, image_sampler_state] = texture_from_file(path, settings);
-    return { id, width, height, number_of_components , type, texture_2d, shader_resource_view, image_sampler_state, path };
+    return std::make_shared<Texture>(id, width, height, number_of_components , type, texture_2d, shader_resource_view, image_sampler_state, path);
 }
 
-Texture TextureLoader::load_cubemap(std::vector<std::string> const& paths, TextureType const type,
-                                    TextureSettings const& settings)
+std::shared_ptr<Texture> TextureLoader::load_cubemap(std::vector<std::string> const &paths, TextureType const type,
+                                                     TextureSettings const &settings)
 {
     assert(paths.size() > 0);
 
     auto const [id, width, height, number_of_components, texture_2d, shader_resource_view, image_sampler_state] = cubemap_from_files(paths, settings);
-    return { id, width, height, number_of_components , type, texture_2d, shader_resource_view, image_sampler_state, paths[0] };
+    return std::make_shared<Texture>(id, width, height, number_of_components , type, texture_2d, shader_resource_view, image_sampler_state, paths[0]);
 }

--- a/src/TextureLoader.h
+++ b/src/TextureLoader.h
@@ -22,8 +22,10 @@ class TextureLoader
 public:
     virtual ~TextureLoader() = default;
 
-    [[nodiscard]] Texture load_texture(std::string const& path, TextureType const type, TextureSettings const& settings = {});
-    [[nodiscard]] Texture load_cubemap(std::vector<std::string> const& paths, TextureType const type, TextureSettings const& settings = {});
+    [[nodiscard]] std::shared_ptr<Texture> load_texture(std::string const &path, TextureType const type,
+                                                        TextureSettings const &settings = {});
+    [[nodiscard]] std::shared_ptr<Texture> load_cubemap(std::vector<std::string> const &paths, TextureType const type,
+                                                        TextureSettings const &settings = {});
 
     static std::shared_ptr<TextureLoader> get_instance()
     {

--- a/src/TextureLoader.h
+++ b/src/TextureLoader.h
@@ -6,6 +6,8 @@
 
 #include "Texture.h"
 
+class ResourceManager;
+
 struct TextureData
 {
     u32 id = 0;
@@ -22,11 +24,6 @@ class TextureLoader
 public:
     virtual ~TextureLoader() = default;
 
-    [[nodiscard]] std::shared_ptr<Texture> load_texture(std::string const &path, TextureType const type,
-                                                        TextureSettings const &settings = {});
-    [[nodiscard]] std::shared_ptr<Texture> load_cubemap(std::vector<std::string> const &paths, TextureType const type,
-                                                        TextureSettings const &settings = {});
-
     static std::shared_ptr<TextureLoader> get_instance()
     {
         return m_instance;
@@ -41,6 +38,13 @@ protected:
 private:
     inline static std::shared_ptr<TextureLoader> m_instance;
 
+    [[nodiscard]] std::shared_ptr<Texture> load_texture(std::string const &path, TextureType const type,
+                                                        TextureSettings const &settings = {});
+    [[nodiscard]] std::shared_ptr<Texture> load_cubemap(std::vector<std::string> const &paths, TextureType const type,
+                                                        TextureSettings const &settings = {});
+
     TextureData virtual texture_from_file(std::string const& path, TextureSettings const settings) = 0;
     TextureData virtual cubemap_from_files(std::vector<std::string> const& paths, TextureSettings const settings) = 0;
+
+    friend class ResourceManager;
 };

--- a/src/TextureLoaderDX11.cpp
+++ b/src/TextureLoaderDX11.cpp
@@ -10,10 +10,6 @@ std::shared_ptr<TextureLoaderDX11> TextureLoaderDX11::create()
     return texture_loader;
 }
 
-void TextureLoaderDX11::clean_up() const
-{
-}
-
 TextureData TextureLoaderDX11::texture_from_file(std::string const& path, TextureSettings const settings)
 {
     auto const device = RendererDX11::get_instance_dx11()->get_device();

--- a/src/TextureLoaderDX11.h
+++ b/src/TextureLoaderDX11.h
@@ -10,7 +10,6 @@ public:
     static std::shared_ptr<TextureLoaderDX11> create();
 
 private:
-    void clean_up() const;
     virtual TextureData texture_from_file(std::string const& path, TextureSettings const settings) override;
     virtual TextureData cubemap_from_files(std::vector<std::string> const& paths, TextureSettings const settings) override;
 

--- a/src/yaml-cpp-extensions.h
+++ b/src/yaml-cpp-extensions.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ResourceManager.h"
+
 #include <xstring>
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
@@ -125,11 +127,11 @@ namespace YAML
 
             if (geometry_path.empty())
             {
-                rhs = ShaderFactory::create(vertex_path, fragment_path);
+                rhs = ResourceManager::get_instance().load_shader(vertex_path, fragment_path);
             }
             else
             {
-                rhs = ShaderFactory::create(vertex_path, fragment_path, geometry_path);
+                rhs = ResourceManager::get_instance().load_shader(vertex_path, fragment_path, geometry_path);
             }
 
             return true;


### PR DESCRIPTION
ResourceManager is now an interface for loading Textures, Shaders and Models. Whenever you want to obtain a resource, you simply call a proper load_xxx() method. ResourceManager will return a resource. If it had been loaded previously, it won't load the resource again but return a shared pointer to the desired resource in memory. When all the references to the resource are gone, it is automatically unloaded from memory.

This has been tested, but still needs **more insight**. I assume it works for models loaded with Assimp, single- or multiple-meshed, also for derived models based on generated meshes, such as Cubes, Sprites and Spheres (tested for Spheres, Sprites, many various models etc.).

I recommend checking different variations of materials, models and textures, making sure that only things we want to be shared are shared, and so on...

This system needed changes to be made in many places in the codebase, so we can think of the best way to split this into multiple commits. 