### PR TITLE
PhysicsEngine+Component: Introduce a new physics update

### DIFF
--- a/src/Collider2D.cpp
+++ b/src/Collider2D.cpp
@@ -354,7 +354,7 @@ void Collider2D::physics_update()
     if (glm::epsilonEqual(velocity, {0.0f, 0.0f}, 0.001f) != glm::bvec2(true, true))
     {
         entity->transform->set_position(entity->transform->get_position()
-                                        + AK::convert_2d_to_3d(velocity) * static_cast<float>(delta_time));
+                                        + AK::convert_2d_to_3d(velocity) * static_cast<float>(fixed_delta_time));
 
         velocity = AK::move_towards(velocity, {0.0f, 0.0f}, drag);
     }

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -37,6 +37,10 @@ void Component::update()
 {
 }
 
+void Component::fixed_update()
+{
+}
+
 void Component::on_enabled()
 {
 }

--- a/src/Component.h
+++ b/src/Component.h
@@ -24,6 +24,7 @@ public:
     virtual void awake();
     virtual void start();
     virtual void update();
+    virtual void fixed_update();
     virtual void on_enabled();
     virtual void on_disabled();
     virtual void on_destroyed();

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -181,7 +181,7 @@ void Engine::run()
 
         if (m_is_game_running && !m_is_game_paused)
         {
-            PhysicsEngine::get_instance()->update_physics();
+            PhysicsEngine::get_instance()->run_updates();
             MainScene::get_instance()->run_frame();
         }
 

--- a/src/Game/Customer.cpp
+++ b/src/Game/Customer.cpp
@@ -8,6 +8,7 @@
 #include "GameController.h"
 #include "Globals.h"
 #include "LighthouseKeeper.h"
+#include "PhysicsEngine.h"
 #include "SceneSerializer.h"
 
 #include <glm/gtc/random.hpp>
@@ -35,7 +36,7 @@ void Customer::awake()
     m_spreading_arms_timer = glm::linearRand(m_spread_arms_min, m_spread_arms_max);
 }
 
-void Customer::update()
+void Customer::fixed_update()
 {
     if (entity == nullptr || entity->transform == nullptr || left_hand.expired() || right_hand.expired())
     {
@@ -54,7 +55,7 @@ void Customer::update()
 
     float const y = entity->transform->get_position().y;
 
-    float const delta_time_f = static_cast<float>(delta_time);
+    float constexpr delta_time_f = fixed_delta_time;
 
     glm::vec3 const current_position = entity->transform->get_position();
     glm::vec2 const current_position_2d = AK::convert_3d_to_2d(current_position);

--- a/src/Game/Customer.h
+++ b/src/Game/Customer.h
@@ -14,7 +14,7 @@ public:
     explicit Customer(AK::Badge<Customer>);
 
     virtual void awake() override;
-    virtual void update() override;
+    virtual void fixed_update() override;
     virtual void on_collision_enter(std::shared_ptr<Collider2D> const& other) override;
 
 #if EDITOR

--- a/src/Game/LighthouseKeeper.cpp
+++ b/src/Game/LighthouseKeeper.cpp
@@ -11,6 +11,7 @@
 #include "IceBound.h"
 #include "LevelController.h"
 #include "Lighthouse.h"
+#include "PhysicsEngine.h"
 #include "Player.h"
 #include "Port.h"
 #include "ResourceManager.h"
@@ -54,6 +55,10 @@ void LighthouseKeeper::update()
                                                        Camera::get_main_camera()->get_position(), false);
         m_engine_sound->set_volume(2.0f);
     }
+}
+
+void LighthouseKeeper::fixed_update()
+{
     m_engine_sound->entity->transform->set_position(entity->transform->get_position());
     i32 horizontal = 0;
     i32 vertical = 0;
@@ -104,7 +109,7 @@ void LighthouseKeeper::update()
     }
 
     glm::vec3 speed_vector = glm::vec3(m_speed.x, 0.0f, m_speed.y);
-    speed_vector *= delta_time;
+    speed_vector *= fixed_delta_time;
 
     entity->transform->set_local_position(entity->transform->get_local_position() + speed_vector);
 

--- a/src/Game/LighthouseKeeper.h
+++ b/src/Game/LighthouseKeeper.h
@@ -25,6 +25,8 @@ public:
 
     virtual void awake() override;
     virtual void update() override;
+    virtual void fixed_update() override;
+
 #if EDITOR
     virtual void draw_editor() override;
 #endif

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -9,6 +9,7 @@
 #include "Vertex.h"
 
 inline double delta_time;
+inline double constexpr fixed_delta_time = 0.008333;
 
 inline i32 SKYBOX_RENDER_ORDER = 100;
 

--- a/src/PhysicsEngine.cpp
+++ b/src/PhysicsEngine.cpp
@@ -5,6 +5,7 @@
 #include "Debug.h"
 #include "Engine.h"
 #include "Entity.h"
+#include "Globals.h"
 
 void PhysicsEngine::initialize()
 {
@@ -12,8 +13,25 @@ void PhysicsEngine::initialize()
     set_instance(physics_engine);
 }
 
+// https://gamedevfaqs.com/managing-consistent-game-physics-the-case-for-fixed-time-steps/
+void PhysicsEngine::run_updates()
+{
+    m_accumulated_delta += delta_time;
+
+    i32 const iterations = static_cast<i32>(m_accumulated_delta / fixed_delta_time);
+
+    m_accumulated_delta -= fixed_delta_time * iterations;
+
+    for (i32 i = iterations; i > 0; i--)
+    {
+        update_physics();
+    }
+}
+
 void PhysicsEngine::update_physics() const
 {
+    MainScene::get_instance()->run_physics_frame();
+
     for (auto const& collider : colliders)
     {
         collider->physics_update();

--- a/src/PhysicsEngine.h
+++ b/src/PhysicsEngine.h
@@ -31,7 +31,7 @@ public:
     void operator=(PhysicsEngine const&) = delete;
 
     void initialize();
-    void update_physics() const; // TODO: All physics calculations should be in some kind of FixedUpdate
+    void run_updates();
 
     static void on_collision_enter(std::shared_ptr<Collider2D> const& collider, std::shared_ptr<Collider2D> const& other);
     static void on_collision_exit(std::shared_ptr<Collider2D> const& collider, std::shared_ptr<Collider2D> const& other);
@@ -46,6 +46,7 @@ public:
     static bool compute_penetration(std::shared_ptr<Collider2D> const& collider, std::shared_ptr<Collider2D> const& other, glm::vec2& mtv);
 
 private:
+    void update_physics() const;
     void solve_collisions() const;
 
     static bool test_collision_rectangle_rectangle(Collider2D const& obb1, Collider2D const& obb2, glm::vec2& mtv);
@@ -58,5 +59,8 @@ private:
     static bool is_point_inside_obb(glm::vec2 const& point, std::array<glm::vec2, 4> const& rectangle_corners);
 
     std::vector<std::shared_ptr<Collider2D>> colliders = {};
+
+    double m_accumulated_delta = 0.0;
+
     inline static std::shared_ptr<PhysicsEngine> m_instance;
 };

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -148,3 +148,15 @@ void Scene::run_frame()
         component->update();
     }
 }
+
+void Scene::run_physics_frame() const
+{
+    auto const components_copy = tickable_components;
+    for (auto const& component : components_copy)
+    {
+        if (component == nullptr || component->entity == nullptr || !component->enabled())
+            continue;
+
+        component->fixed_update();
+    }
+}

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -26,6 +26,7 @@ public:
     [[nodiscard]] std::shared_ptr<Component> get_component_by_guid(std::string const& guid) const;
 
     void run_frame();
+    void run_physics_frame() const;
 
     bool is_running = false;
 


### PR DESCRIPTION
That runs at constant intervals. Change penguins and lighthouse keeper to use this fixed_update instead of regular update, which fixes physics bugs in low (and high) fps.